### PR TITLE
Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk8
+install: echo 'Skipping install phase'
+script: mvn verify


### PR DESCRIPTION
These file tells travis to build the project using java 1.8, skip the install phase (maven just don't need it) and run maven goal "verify" to include integration tests to the main phase. 
