### PR TITLE
Disable cglib enhancer class cache

### DIFF
--- a/restler-core/src/main/java/org/restler/client/CGLibClientFactory.java
+++ b/restler-core/src/main/java/org/restler/client/CGLibClientFactory.java
@@ -28,6 +28,7 @@ public class CGLibClientFactory implements ClientFactory {
         InvocationHandler handler = coreModule.createHandler(descriptor);
 
         Enhancer enhancer = new Enhancer();
+        enhancer.setUseCache(false);
         enhancer.setSuperclass(serviceDescriptor);
         enhancer.setCallbackType(handler.getClass());
 

--- a/restler-core/src/test/groovy/org/restler/client/CGLibClientFactorySpec.groovy
+++ b/restler-core/src/test/groovy/org/restler/client/CGLibClientFactorySpec.groovy
@@ -22,23 +22,27 @@ class CGLibClientFactorySpec extends Specification {
         proxy != null
     }
 
-    class InvocationHandlerStub implements InvocationHandler {
+    def "CGLibClientFactory should create independent proxies of same class"() {
+        given:
+        def module = Mock(CoreModule)
+        module.canHandle(_) >> true
 
-        @Override
-        Object invoke(Object o, Method method, Object[] objects) throws Throwable {
-            return null
-        }
+        def invocationHandler1 = new InvocationHandlerStub()
+        def invocationHandler2 = new InvocationHandlerStub()
+        module.createHandler(_) >>> [invocationHandler1, invocationHandler2]
 
+        def factory = new CGLibClientFactory(module)
+
+        when:
+        def proxy1 = factory.produceClient(ControllerWithoutDefaultConstructor.class)
+        def proxy2 = factory.produceClient(ControllerWithoutDefaultConstructor.class)
+
+        proxy1.someMethod("any")
+        proxy2.someMethod("any")
+
+        then:
+        invocationHandler1.callsCount == 1
+        invocationHandler2.callsCount == 1
     }
 
-    class ControllerWithoutDefaultConstructor {
-
-        private final Object someDependency;
-
-        public ControllerWithoutDefaultConstructor(Object someDependency) {
-            this.someDependency = someDependency;
-        }
-
-    }
 }
-

--- a/restler-core/src/test/java/org/restler/client/ControllerWithoutDefaultConstructor.java
+++ b/restler-core/src/test/java/org/restler/client/ControllerWithoutDefaultConstructor.java
@@ -1,0 +1,12 @@
+package org.restler.client;
+
+public class ControllerWithoutDefaultConstructor {
+
+    private final Object someDependency;
+
+    public ControllerWithoutDefaultConstructor(Object someDependency) {
+        this.someDependency = someDependency;
+    }
+
+    void someMethod(String arg) {}
+}

--- a/restler-core/src/test/java/org/restler/client/InvocationHandlerStub.java
+++ b/restler-core/src/test/java/org/restler/client/InvocationHandlerStub.java
@@ -1,0 +1,17 @@
+package org.restler.client;
+
+import net.sf.cglib.proxy.InvocationHandler;
+
+import java.lang.reflect.Method;
+
+public class InvocationHandlerStub implements InvocationHandler {
+
+    int callsCount;
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        callsCount++;
+        return null;
+    }
+
+}


### PR DESCRIPTION
Disable cglib enhancer class cache
This fixes the bug introduced in the previous release.
Initially, the problem was that the Restler was unable to proxy classes without default constructor. To solve this problem, Objenesis was used to create objects without calling the constructor. But to use Objenesis as objects factory, it was necessary to link proxy with invocation handler by proxy's class. Since in cglib classes cache was enabled by default, different proxies have the same class and was linked to the same invocation handler. In order to solve this problem I had to disable the cache classes cglib.
Closes #97
